### PR TITLE
Disable XML entity expansion when parsing SAML XML

### DIFF
--- a/src/esaml.app.src
+++ b/src/esaml.app.src
@@ -1,7 +1,7 @@
 {application, esaml,
  [
   {description, "SAML for erlang"},
-  {vsn, "1.1.2"},
+  {vsn, "1.1.5"},
   {registered, []},
   {included_applications, [
   ]},

--- a/src/esaml.appup.src
+++ b/src/esaml.appup.src
@@ -1,0 +1,15 @@
+%% -*- mode: erlang -*-
+{"1.1.5",
+ [
+   {<<".*">>, [
+     {load_module, esaml_binding, brutal_purge, soft_purge, []},
+     {load_module, esaml_util, brutal_purge, soft_purge, []}
+   ]}
+ ],
+ [
+   {<<".*">>, [
+     {load_module, esaml_binding, brutal_purge, soft_purge, []},
+     {load_module, esaml_util, brutal_purge, soft_purge, []}
+   ]}
+ ]
+}.

--- a/src/esaml_binding.erl
+++ b/src/esaml_binding.erl
@@ -41,16 +41,22 @@ xml_payload_type(Xml) ->
 %% @doc Unpack and parse a SAMLResponse with given encoding
 -spec decode_response(SAMLEncoding :: binary(), SAMLResponse :: binary()) -> #xmlDocument{}.
 decode_response(?deflate, SAMLResponse) ->
-	XmlData = binary_to_list(zlib:unzip(base64:decode(SAMLResponse))),
-	{Xml, _} = xmerl_scan:string(XmlData, [{namespace_conformant, true}]),
-    Xml;
+    scan_xml(zlib:unzip(base64:decode(SAMLResponse)));
 decode_response(_, SAMLResponse) ->
 	Data = base64:decode(SAMLResponse),
     XmlData = case (catch zlib:unzip(Data)) of
-        {'EXIT', _} -> binary_to_list(Data);
-        Bin -> binary_to_list(Bin)
+        {'EXIT', _} -> Data;
+        Bin -> Bin
     end,
-	{Xml, _} = xmerl_scan:string(XmlData, [{namespace_conformant, true}]),
+    scan_xml(XmlData).
+
+scan_xml(XmlData) when is_binary(XmlData) ->
+    scan_xml(binary_to_list(XmlData));
+scan_xml(XmlData) ->
+	{Xml, _} = xmerl_scan:string(XmlData, [
+        {namespace_conformant, true},
+        {allow_entities, false}
+    ]),
     Xml.
 
 %% @doc Encode a SAMLRequest (or SAMLResponse) as an HTTP-REDIRECT binding
@@ -141,6 +147,57 @@ generate_post_html(Type, Dest, Req, RelayState) ->
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+
+decode_response_rejects_external_entity_test() ->
+    File = secret_file(),
+    ok = file:write_file(File, <<"sensitive">>),
+    try
+        SAMLResponse = base64:encode(malicious_response(File)),
+        assert_entities_not_allowed(catch decode_response(<<"post">>, SAMLResponse))
+    after
+        file:delete(File)
+    end.
+
+decode_response_rejects_deflated_external_entity_test() ->
+    File = secret_file(),
+    ok = file:write_file(File, <<"sensitive">>),
+    try
+        SAMLResponse = base64:encode(zlib:zip(malicious_response(File))),
+        assert_entities_not_allowed(catch decode_response(?deflate, SAMLResponse))
+    after
+        file:delete(File)
+    end.
+
+decode_response_rejects_internal_entity_test() ->
+    SAMLResponse = base64:encode(internal_entity_response()),
+    assert_entities_not_allowed(catch decode_response(<<"post">>, SAMLResponse)).
+
+decode_response_allows_predefined_entity_test() ->
+    SAMLResponse = base64:encode(<<"<Response>Tom &amp; Jerry</Response>">>),
+    #xmlElement{content = [#xmlText{value = "Tom & Jerry"}]} =
+        decode_response(<<"post">>, SAMLResponse).
+
+assert_entities_not_allowed(Result) ->
+    ?assertMatch(
+        {'EXIT', {fatal, {{error, entities_not_allowed}, _, _, _}}},
+        Result
+    ).
+
+secret_file() ->
+    filename:join([
+        os:getenv("TMPDIR", "/tmp"),
+        "esaml_xxe_" ++ integer_to_list(erlang:unique_integer([positive])) ++ ".txt"
+    ]).
+
+malicious_response(File) ->
+    iolist_to_binary([
+        "<?xml version=\"1.0\"?>",
+        "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file://", File, "\">]>",
+        "<Response>&xxe;</Response>"
+    ]).
+
+internal_entity_response() ->
+    <<"<!DOCTYPE foo [<!ENTITY xxe \"sensitive\">]><Response>&xxe;</Response>">>.
 
 -endif.
 

--- a/src/esaml_util.erl
+++ b/src/esaml_util.erl
@@ -202,7 +202,7 @@ load_metadata(Url, FPs) ->
         [{Url, Meta}] -> Meta;
         _ ->
             {ok, {{_Ver, 200, _}, _Headers, Body}} = httpc:request(get, {Url, []}, [{autoredirect, true}], []),
-            {Xml, _} = xmerl_scan:string(Body, [{namespace_conformant, true}]),
+            Xml = scan_xml(Body),
             case xmerl_dsig:verify(Xml, Fingerprints) of
                 ok -> ok;
                 Err -> error(Err)
@@ -219,11 +219,20 @@ load_metadata(Url) ->
         [{Url, Meta}] -> Meta;
         _ ->
             {ok, {{_Ver, 200, _}, _Headers, Body}} = httpc:request(get, {Url, []}, [{autoredirect, true}], []),
-            {Xml, _} = xmerl_scan:string(Body, [{namespace_conformant, true}]),
+            Xml = scan_xml(Body),
             {ok, Meta = #esaml_idp_metadata{}} = esaml:decode_idp_metadata(Xml),
             ets:insert(esaml_idp_meta_cache, {Url, Meta}),
             Meta
     end.
+
+scan_xml(XmlData) when is_binary(XmlData) ->
+    scan_xml(binary_to_list(XmlData));
+scan_xml(XmlData) ->
+    {Xml, _} = xmerl_scan:string(XmlData, [
+        {namespace_conformant, true},
+        {allow_entities, false}
+    ]),
+    Xml.
 
 %% @doc Checks for a duplicate assertion using ETS tables in memory on all available nodes.
 %%
@@ -340,5 +349,37 @@ xpath_text_test() ->
     Fun3 = ?xpath_text("/a/b[@name='bar']/c/text()", b, name),
     Rec3 = Fun3(Rec2),
     ?assertMatch(Rec2, Rec3).
+
+scan_xml_rejects_external_entity_test() ->
+    File = secret_file(),
+    ok = file:write_file(File, <<"sensitive">>),
+    try
+        assert_entities_not_allowed(catch scan_xml(malicious_xml(File)))
+    after
+        file:delete(File)
+    end.
+
+scan_xml_allows_predefined_entity_test() ->
+    #xmlElement{content = [#xmlText{value = "Tom & Jerry"}]} =
+        scan_xml(<<"<EntityDescriptor>Tom &amp; Jerry</EntityDescriptor>">>).
+
+assert_entities_not_allowed(Result) ->
+    ?assertMatch(
+        {'EXIT', {fatal, {{error, entities_not_allowed}, _, _, _}}},
+        Result
+    ).
+
+secret_file() ->
+    filename:join([
+        os:getenv("TMPDIR", "/tmp"),
+        "esaml_metadata_xxe_" ++ integer_to_list(erlang:unique_integer([positive])) ++ ".txt"
+    ]).
+
+malicious_xml(File) ->
+    iolist_to_binary([
+        "<?xml version=\"1.0\"?>",
+        "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file://", File, "\">]>",
+        "<EntityDescriptor>&xxe;</EntityDescriptor>"
+    ]).
 
 -endif.


### PR DESCRIPTION
## Summary

Fixes emqx/emqx-dev-team-tasks#87 (`[5.8] Deps: esaml XXE CVE-2026-28809`).

Disable XML entity expansion when parsing SAML XML in `esaml`.

`esaml_binding:decode_response/2` now uses a shared XML scan helper for both HTTP-Redirect/DEFLATE and fallback POST-style SAML response decoding. `esaml_util:load_metadata/1,2` now uses the same safe XML scan behavior when parsing remote IdP metadata.

The previous implementation called `xmerl_scan:string/2` with only `{namespace_conformant, true}`, so crafted SAML XML could define and expand custom XML entities during parsing.

The added tests cover external entity rejection, internal custom entity rejection, DEFLATE response handling, and normal predefined XML escaping such as `&amp;`.

This also bumps the `esaml` app version to `1.1.5` and adds `src/esaml.appup.src` with version `1.1.5` so relup can load the changed `esaml_binding` and `esaml_util` modules during upgrade or downgrade.

## Tests

- `docker run --rm -u "$(id -u):$(id -g)" -e HOME=/tmp -v "$PWD":/esaml -w /esaml ghcr.io/emqx/emqx-builder/5.6-2:1.15.7-26.2.5.14-1-ubuntu22.04 bash -lc 'rebar3 eunit'`\n- `erl -noshell -eval 'io:format("~p~n", [file:consult("src/esaml.appup.src")]), halt().'`\n- `git diff --check`